### PR TITLE
Change min_ansible_version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,6 +4,6 @@ galaxy_info:
   description: Install and configure Prometheus and exporters
   company: brainsys
   license: GPLv3
-  min_ansible_version: 2.7
+  min_ansible_version: 2.8
   issue_tracker_url: https://github.com/brainsys-io/ansible-role-prometheus/issues
   github_branch: master


### PR DESCRIPTION
The role doesn't work with ansible 2.7.18 :

```
TASK [prometheus : prometheus | include asserts] **************************************************************************************************************
fatal: [host]: FAILED! => {"reason": "no action detected in task. This often indicates a misspelled module name, or incorrect module path.\n\nThe error appears to have been in '/usr/local/ansible/orchestrator/roles/prometheus/tasks/asserts.yml': line 9, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: 'prometheus | assert | gather the package facts'\n  ^ here\n"}
```

Ansible 2.8.20 is OK.